### PR TITLE
Add handling for when Selenium returns 200, but didn't find the element

### DIFF
--- a/src/selenium.lisp
+++ b/src/selenium.lisp
@@ -32,8 +32,10 @@
   (handler-case
       (let ((response (http-post (session-path session "/element") `(:value ,value :using ,(by by)))))
         ;; TODO: find/write json -> clos
-        (make-instance 'element
-                       :id (cdadr (assoc :value response))))
+        (if (= 0 (cdr (assoc :status response)))
+            (make-instance 'element
+                           :id (cdadr (assoc :value response)))
+            (error 'protocol-error :body response)))
     (protocol-error (err) (handle-find-error err :value value :by by))))
 
 (defun find-elements (value &key (by :css-selector) (session *session*))


### PR DESCRIPTION
Found what seems to be a bug or other protocol change.

When attempting to find an element that does not yet exist the code will blindly move forward with the error message as the id for the element and cause an error down the line that manifests as a non-JSON decode-able response from Selenium. This checks the status code to see if it's a Success code, if not, use the existing error handling to signal error. It seems to correct the issue for my limited use case. I suspect find-elements is similarly broken, but haven't made changes there.

Tests run except for 1 that expects a less detailed id (print-element) and a few that don't work because Google changed their design for the Russian homepage.

N.B. I am NOT a great LISPer by any stretch of the imagination. Feedback is highly encouraged.