### PR TITLE
Add argument for adding arbitrary capabilities to make-session

### DIFF
--- a/src/session.lisp
+++ b/src/session.lisp
@@ -12,14 +12,16 @@
                        browser-version
                        platform-name
                        platform-version
-                       accept-ssl-certs)
+                       accept-ssl-certs
+                       additional-capabilities)
   (let ((response (http-post "/session"
                              `(:session-id nil
-                                           :desired-capabilities ((browser-name . ,browser-name)
-                                                                  (browser-version . ,browser-version)
-                                                                  (platform-name . ,platform-name)
-                                                                  (platform-version . ,platform-version)
-                                                                  (accept-ssl-certs . ,accept-ssl-certs))))))
+                               :desired-capabilities ((browser-name . ,browser-name)
+                                                      (browser-version . ,browser-version)
+                                                      (platform-name . ,platform-name)
+                                                      (platform-version . ,platform-version)
+                                                      (accept-ssl-certs . ,accept-ssl-certs)
+                                                      ,@additional-capabilities)))))
     ;; TODO: find/write json -> clos
     (make-instance 'session
                    :id (assoc-value response :session-id))))


### PR DESCRIPTION
This change lets make-session accept an optional
'additional-capabilities' key argument, the content of which is
spliced into the plist used to generate the capabilities sent to
Selenium.

This can be used to make, for example, headless Chrome sessions for
use in CI systems:

```lisp
(with-session
     ;; Configure headless Chrome instance:
    (:additional-capabilities
     '((:chrome-options . ((:args . #("--headless"))))))

  (some-stuff))
```

(Note: The indentation change is the recommend indentation in Emacs'
lisp-mode)